### PR TITLE
fixes sonar testnet endpoint

### DIFF
--- a/assemblyscript/deploy/testnet/deploy-test.js
+++ b/assemblyscript/deploy/testnet/deploy-test.js
@@ -1,7 +1,7 @@
 const { deploy } = require('../scripts/deploy');
 
 deploy(
-  'testnet.redstone.tools',
+  'sonar.warp.cc',
   443,
   'https',
   'testnet',

--- a/assemblyscript/deploy/testnet/interact-balance-testnet.js
+++ b/assemblyscript/deploy/testnet/interact-balance-testnet.js
@@ -1,7 +1,7 @@
 const { interactBalance } = require('../scripts/interact-balance');
 
 interactBalance(
-  'testnet.redstone.tools',
+  'sonar.warp.cc',
   443,
   'https',
   'testnet',

--- a/assemblyscript/deploy/testnet/interact-transfer-testnet.js
+++ b/assemblyscript/deploy/testnet/interact-transfer-testnet.js
@@ -1,7 +1,7 @@
 const { interactTransfer } = require('../scripts/interact-transfer');
 
 interactTransfer(
-  'testnet.redstone.tools',
+  'sonar.warp.cc',
   443,
   'https',
   'testnet',

--- a/assemblyscript/deploy/testnet/read-contract-state-testnet.js
+++ b/assemblyscript/deploy/testnet/read-contract-state-testnet.js
@@ -1,7 +1,7 @@
 const { readContractState } = require('../scripts/read-contract-state');
 
 readContractState(
-  'testnet.redstone.tools',
+  'sonar.warp.cc',
   443,
   'https',
   'testnet',

--- a/go/deploy/testnet/deploy-test.js
+++ b/go/deploy/testnet/deploy-test.js
@@ -1,7 +1,7 @@
 const { deploy } = require('../scripts/deploy');
 
 deploy(
-  'testnet.redstone.tools',
+  'sonar.warp.cc',
   443,
   'https',
   'testnet',

--- a/go/deploy/testnet/interact-balance-testnet.js
+++ b/go/deploy/testnet/interact-balance-testnet.js
@@ -1,7 +1,7 @@
 const { interactBalance } = require('../scripts/interact-balance');
 
 interactBalance(
-  'testnet.redstone.tools',
+  'sonar.warp.cc',
   443,
   'https',
   'testnet',

--- a/go/deploy/testnet/interact-transfer-testnet.js
+++ b/go/deploy/testnet/interact-transfer-testnet.js
@@ -1,7 +1,7 @@
 const { interactTransfer } = require('../scripts/interact-transfer');
 
 interactTransfer(
-  'testnet.redstone.tools',
+  'sonar.warp.cc',
   443,
   'https',
   'testnet',

--- a/go/deploy/testnet/read-contract-state-testnet.js
+++ b/go/deploy/testnet/read-contract-state-testnet.js
@@ -1,7 +1,7 @@
 const { readContractState } = require('../scripts/read-contract-state');
 
 readContractState(
-  'testnet.redstone.tools',
+  'sonar.warp.cc',
   443,
   'https',
   'testnet',

--- a/rust/pst/deploy/testnet/interact-balance-testnet.js
+++ b/rust/pst/deploy/testnet/interact-balance-testnet.js
@@ -1,7 +1,7 @@
 const { interactBalance } = require('../scripts/interact-balance');
 
 interactBalance(
-  'testnet.redstone.tools',
+  'sonar.warp.cc',
   443,
   'https',
   'testnet',

--- a/rust/pst/deploy/testnet/interact-transfer-testnet.js
+++ b/rust/pst/deploy/testnet/interact-transfer-testnet.js
@@ -1,7 +1,7 @@
 const { interactTransfer } = require('../scripts/interact-transfer');
 
 interactTransfer(
-  'testnet.redstone.tools',
+  'sonar.warp.cc',
   443,
   'https',
   'testnet',

--- a/rust/pst/deploy/testnet/read-contract-state-testnet.js
+++ b/rust/pst/deploy/testnet/read-contract-state-testnet.js
@@ -1,7 +1,7 @@
 const { readContractState } = require('../scripts/read-contract-state');
 
 readContractState(
-  'testnet.redstone.tools',
+  'sonar.warp.cc',
   443,
   'https',
   'testnet',


### PR DESCRIPTION
# Fix

Fixes the testnet endpoints as `testnet.redstone.tools` has been deprecated